### PR TITLE
Fix entry fee calculation with leverage

### DIFF
--- a/tests/test_tradecalculator.py
+++ b/tests/test_tradecalculator.py
@@ -1,0 +1,21 @@
+from decimal import Decimal
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from trading_bot.core.tradecalculator import TradeCalculator
+
+
+def test_entry_fee_accounts_for_leverage():
+    calc = TradeCalculator(maker_fee=Decimal('0.0006'), taker_fee=Decimal('0.0006'))
+    result = calc.calculate_trade(
+        entry_price=Decimal('100'),
+        exit_price=Decimal('110'),
+        risk_capital=Decimal('100'),
+        leverage=10,
+        is_maker=False,
+        holding_days=0,
+        slippage=Decimal('0'),
+    )
+    assert result['total_fee'] == Decimal('1.26')

--- a/trading_bot/core/tradecalculator.py
+++ b/trading_bot/core/tradecalculator.py
@@ -116,7 +116,8 @@ class TradeCalculator:
         position_size = (risk_capital * leverage) / effective_entry
         fee_rate = self.maker_fee if is_maker else self.taker_fee
 
-        entry_fee = risk_capital * fee_rate
+        # Fees are assessed on the notional trade value, which includes leverage
+        entry_fee = position_size * effective_entry * fee_rate
         exit_fee = position_size * effective_exit * fee_rate
         total_fee = entry_fee + exit_fee
 


### PR DESCRIPTION
## Summary
- correct fee computation to use leveraged position size for entry fees
- add test covering leverage-aware fee calculation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4c4ed53588325b1828e93a68b149d