### PR TITLE
fix: correct null adapter import path

### DIFF
--- a/trading_bot/core/branch.py
+++ b/trading_bot/core/branch.py
@@ -12,8 +12,11 @@ from trading_bot.brokers.Exchange_Bybit import Exchange_Bybit
 from trading_bot.brokers.Fetch_IBKR_MarketData import IBKRMarketDataFetcher
 from trading_bot.core.configmanager import config_manager
 from trading_bot.core.loggerconfig import get_logger, setup_logging
-from trading_bot.core.nulladapters import (NullExecution, NullMarketData,
-                                          NullWalletSync)
+from trading_bot.core.null_adapters import (
+    NullExecution,
+    NullMarketData,
+    NullWalletSync,
+)
 from trading_bot.core.schemas import BranchStatus
 from trading_bot.learning.Train_ML_Model import Train_ML_Model
 from trading_bot.learning.Train_RL_Model import \


### PR DESCRIPTION
## Summary
- use proper `null_adapters` module in `Branch` to initialize placeholder components

## Testing
- `pytest -q temp_test_branch.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4f66a166883259463dfa8718007ad