### PR TITLE
Rename Telegram format parameter to parse_mode

### DIFF
--- a/trading_bot/core/notificationmanager.py
+++ b/trading_bot/core/notificationmanager.py
@@ -87,7 +87,7 @@ class NotificationManager:
         """
         Notifies of an error event.
         """
-        await self._send({"type": "ALERT", "message": text}, fmt="alert")
+        await self._send({"type": "ALERT", "message": text})
 
     async def tick(self):
         """
@@ -170,8 +170,8 @@ class NotificationManager:
             parts.append(f"Return: <b>{float(rp):.2f}%</b>")
         return "\n".join(parts)
 
-    async def _send(self, content, fmt: str = "text"):
+    async def _send(self, content, parse_mode: Optional[str] = None):
         try:
-            await self.notifier.send_message_async(content, format=fmt)
+            await self.notifier.send_message_async(content, parse_mode=parse_mode)
         except Exception:
             logger.exception("Notification send failed")

--- a/trading_bot/core/telegram_bot.py
+++ b/trading_bot/core/telegram_bot.py
@@ -1,3 +1,16 @@
+"""Telegram bot utilities for sending notifications.
+
+Example:
+    >>> from trading_bot.core.telegram_bot import TelegramNotifier
+    >>> notifier = TelegramNotifier(token="TOKEN", chat_id="CHAT_ID")
+    >>> import asyncio
+    >>> asyncio.run(
+    ...     notifier.send_message_async("*Hello*", parse_mode="Markdown")
+    ... )
+
+This sends a bold "Hello" using Telegram's Markdown formatting.
+"""
+
 import json
 import logging
 
@@ -11,6 +24,7 @@ from telegram.ext import (
 )
 
 from trading_bot.core.configmanager import config_manager
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -48,20 +62,24 @@ class TelegramNotifier:
         self.bot = Bot(token=self.token)
         self.use_async = not disable_async
 
-    async def send_message_async(self, text: str, format: str = "text"):
-        """
-        Sends a message asynchronously.
+    async def send_message_async(
+        self, text: str, parse_mode: Optional[str] = None
+    ):
+        """Sends a message asynchronously.
 
         Args:
             text: The text of the message to send.
-            format: The format of the message.
+            parse_mode: Telegram parse mode (e.g., ``"Markdown"``, ``"HTML"``)
+                for text formatting.
         """
         if not self.bot:
             return
         try:
             if isinstance(text, dict):
                 text = json.dumps(text, indent=2)
-            await self.bot.send_message(chat_id=self.chat_id, text=str(text))
+            await self.bot.send_message(
+                chat_id=self.chat_id, text=str(text), parse_mode=parse_mode
+            )
         except Exception as e:
             logger.error(f"[Telegram] Failed to send async message: {e}")
 


### PR DESCRIPTION
## Summary
- rename `format` to `parse_mode` and forward to `bot.send_message`
- document parse mode in notifier and add Markdown usage example
- align notification manager with new parameter

## Testing
- `python -m py_compile trading_bot/core/telegram_bot.py trading_bot/core/notificationmanager.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4f671b2448325926d0257d8250a77