### PR TITLE
Implement advanced sizing and ML utilities

### DIFF
--- a/tests/test_ml_and_regime.py
+++ b/tests/test_ml_and_regime.py
@@ -1,0 +1,39 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from tradingbot.core.pair_manager import PairManager
+from tradingbot.learning.train_ml_model import (
+    purged_train_test_split,
+    triple_barrier_label,
+)
+
+
+def test_triple_barrier_labels():
+    prices = pd.Series([100, 103, 98, 105])
+    labels = triple_barrier_label(prices, 0.02, 0.02, 3)
+    assert list(labels) == [1, -1, 1, 0]
+
+
+def test_purged_split_applies_embargo():
+    train, test = purged_train_test_split(100, test_size=0.2, embargo_pct=0.05)
+    # last 5 observations of train removed due to embargo
+    assert train[-1] == 74  # 80 - 5 - 1
+    assert test[0] == 80
+
+
+def test_pair_manager_tag_regimes():
+    df = pd.DataFrame(
+        {
+            "close": [100, 101, 102, 103, 104, 105],
+            "volume": [2e6] * 6,
+        }
+    )
+    pm = PairManager()
+    regimes = pm.tag_regimes(df)
+    assert regimes["volatility"] in {"LOW", "HIGH"}
+    assert regimes["trend"] == "UP"
+    assert regimes["liquidity"] == "HIGH"

--- a/tests/test_risk_manager_extra.py
+++ b/tests/test_risk_manager_extra.py
@@ -8,10 +8,25 @@ sys.path.append(str(Path(__file__).resolve().parent.parent))
 from tradingbot.core.risk_manager import RiskManager
 
 
-def test_compute_size_respects_risk():
-    rm = RiskManager(balance=1000.0, risk_per_trade=0.02)
-    notional = rm.compute_size(price=100.0, stop_loss=90.0)
-    assert notional == pytest.approx(200.0)
+def test_learning_phase_uses_fixed_notional():
+    rm = RiskManager(balance=500.0)
+    size = rm.compute_size(price=100.0, stop_loss=90.0)
+    assert size == 10.0
+
+
+def test_growth_phase_applies_tiers_and_weights():
+    rm = RiskManager(balance=2000.0)
+    # base risk 0.5% -> 2000*0.005=10 risk amount -> /0.1 = 100 notional
+    # strong signal weighting (1.5) -> 150
+    size = rm.compute_size(price=100.0, stop_loss=90.0, signal_strength="strong")
+    assert size == pytest.approx(150.0)
+
+
+def test_drawdown_reduces_risk():
+    rm = RiskManager(balance=2000.0)
+    rm.peak_equity = 4000.0  # 50% drawdown -> floor risk 0.25%
+    size = rm.compute_size(price=100.0, stop_loss=90.0)
+    assert size == pytest.approx(50.0)
 
 
 def test_breach_check_flags_exposure_and_daily_loss():

--- a/tradingbot/core/pair_manager.py
+++ b/tradingbot/core/pair_manager.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from typing import List
+from typing import List, Dict
+
+import pandas as pd
 
 
 class PairManager:
@@ -17,6 +19,43 @@ class PairManager:
 
     def current_universe(self) -> List[str]:
         return list(self._default)
+
+    # ------------------------------------------------------------------
+    def tag_regimes(self, df: pd.DataFrame) -> Dict[str, str]:
+        """Classify simple market regimes from price data.
+
+        Parameters
+        ----------
+        df:
+            DataFrame with ``close`` and ``volume`` columns.
+
+        Returns
+        -------
+        dict
+            Mapping of regime type (``volatility``, ``trend``, ``liquidity``) to
+            a qualitative label.  The logic is intentionally lightweight but
+            deterministic so unit tests can exercise the behaviour.
+        """
+
+        if df.empty:
+            return {"volatility": "LOW", "trend": "SIDEWAYS", "liquidity": "LOW"}
+
+        returns = df["close"].pct_change().dropna()
+        vol = returns.std()
+        volatility = "HIGH" if vol > 0.02 else "LOW"
+
+        sma = df["close"].rolling(20, min_periods=1).mean()
+        last = df["close"].iloc[-1]
+        base = sma.iloc[-1]
+        if last > base * 1.01:
+            trend = "UP"
+        elif last < base * 0.99:
+            trend = "DOWN"
+        else:
+            trend = "SIDEWAYS"
+
+        liquidity = "HIGH" if df.get("volume", pd.Series()).mean() > 1_000_000 else "LOW"
+        return {"volatility": volatility, "trend": trend, "liquidity": liquidity}
 
 
 __all__ = ["PairManager"]

--- a/tradingbot/learning/train_ml_model.py
+++ b/tradingbot/learning/train_ml_model.py
@@ -1,7 +1,12 @@
 from tradingbot.core.loggerconfig import get_logger
 # In a real scenario, this would depend on a market data interface
 # from tradingbot.core.interfaces import IMarketDataFetcher
-from tradingbot.brokers.exchangebybit import ExchangeBybit
+try:  # pragma: no cover - defensive import
+    from tradingbot.brokers.exchangebybit import ExchangeBybit
+except Exception:  # pragma: no cover
+    ExchangeBybit = object  # type: ignore
+import numpy as np
+import pandas as pd
 
 
 class TrainMLModel:
@@ -46,3 +51,73 @@ class TrainMLModel:
 
         self.log.info("Crypto strategy training/analysis complete.")
         return model_artifact, metrics
+
+
+# ---------------------------------------------------------------------------
+# Utility functions used in unit tests
+# ---------------------------------------------------------------------------
+
+def triple_barrier_label(
+    prices: pd.Series,
+    upper_pct: float,
+    lower_pct: float,
+    max_holding: int,
+) -> pd.Series:
+    """Apply the triple‑barrier method to generate labels.
+
+    Parameters
+    ----------
+    prices:
+        Series of prices indexed by time.
+    upper_pct, lower_pct:
+        Multipliers defining the take‑profit and stop‑loss barriers relative to
+        the price at *t0*.
+    max_holding:
+        Number of periods after which the position is closed regardless of
+        price.
+
+    Returns
+    -------
+    pandas.Series
+        Labels of 1 (upper barrier hit), -1 (lower barrier hit) or 0 (vertical
+        barrier / none).
+    """
+
+    prices = prices.reset_index(drop=True)
+    n = len(prices)
+    labels = np.zeros(n, dtype=int)
+    for i in range(n):
+        start = prices[i]
+        upper = start * (1 + upper_pct)
+        lower = start * (1 - lower_pct)
+        end = min(n, i + max_holding + 1)
+        for j in range(i + 1, end):
+            p = prices[j]
+            if p >= upper:
+                labels[i] = 1
+                break
+            if p <= lower:
+                labels[i] = -1
+                break
+    return pd.Series(labels, index=prices.index)
+
+
+def purged_train_test_split(
+    n_samples: int, test_size: float = 0.2, embargo_pct: float = 0.0
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return indices for a purged train/test split.
+
+    ``embargo_pct`` removes observations from the end of the train set to
+    reduce leakage.  The function works purely with lengths so it can be used
+    with any indexable structure.
+    """
+
+    if not 0 < test_size < 1:
+        raise ValueError("test_size must be between 0 and 1")
+
+    test_start = int(n_samples * (1 - test_size))
+    embargo = int(n_samples * embargo_pct)
+    train_end = max(0, test_start - embargo)
+    train_idx = np.arange(0, train_end)
+    test_idx = np.arange(test_start, n_samples)
+    return train_idx, test_idx


### PR DESCRIPTION
## Summary
- add tiered, drawdown-aware position sizing with signal weighting
- provide regime tagging and ML helpers for triple-barrier labeling and purged splits
- expand unit tests for sizing, regimes, and labeling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6391db8fc832594119658c3efeaef