### PR TITLE
feat: add ranking and sentiment hooks to pair manager

### DIFF
--- a/tests/test_ml_and_regime.py
+++ b/tests/test_ml_and_regime.py
@@ -37,3 +37,11 @@ def test_pair_manager_tag_regimes():
     assert regimes["volatility"] in {"LOW", "HIGH"}
     assert regimes["trend"] == "UP"
     assert regimes["liquidity"] == "HIGH"
+
+
+def test_pair_manager_refresh_and_top():
+    pm = PairManager(default=["AAA", "BBB", "CCC"])
+    pm.set_sentiment(lambda sym: 1.0 if sym == "BBB" else 0.0)
+    uni = pm.refresh_universe()
+    assert uni["crypto"][0] == "BBB"
+    assert pm.get_top(2, "crypto") == uni["crypto"][:2]


### PR DESCRIPTION
## Summary
- implement deterministic universe ranking in PairManager
- allow optional sentiment provider and expose get_top
- extend tests for new PairManager behaviour

## Testing
- `pip check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a711b1e69c8325896f97bd2a661ced