### PR TITLE
Add underscore-free module wrappers

### DIFF
--- a/tradingbot/core/datamanager.py
+++ b/tradingbot/core/datamanager.py
@@ -1,0 +1,70 @@
+# file: core/datamanager.py
+"""DataManager wrapper exposing underscore-free helper methods."""
+
+from __future__ import annotations
+
+import os
+from functools import reduce
+from typing import Callable, Dict, Any
+
+import pandas as pd
+
+from .data_manager import DataManager as _DataManager, _build_paths
+
+
+class DataManager(_DataManager):
+    """Provide a simplified API with new naming conventions."""
+
+    def fetchklines(
+        self,
+        symbol: str,
+        timeframe: str,
+        start: str | None = None,
+        end: str | None = None,
+    ) -> pd.DataFrame:
+        """Fetch cached klines for ``symbol`` and ``timeframe``."""
+        df = self.load_historical_data(symbol, timeframe, incremental=False)
+        if start:
+            df = df[df.index >= pd.to_datetime(start)]
+        if end:
+            df = df[df.index <= pd.to_datetime(end)]
+        return df
+
+    def savelocal(self, df: pd.DataFrame, symbol: str, timeframe: str) -> None:
+        """Persist ``df`` under the standard cache location."""
+        csv_path, _ = _build_paths(symbol, timeframe, self.exchange.client.id)
+        df.to_csv(csv_path)
+
+    def loadlocal(self, symbol: str, timeframe: str) -> pd.DataFrame:
+        """Load cached klines if available."""
+        csv_path, _ = _build_paths(symbol, timeframe, self.exchange.client.id)
+        if os.path.exists(csv_path):
+            df = pd.read_csv(csv_path)
+            return self._normalize_df(df)
+        return pd.DataFrame(columns=["open", "high", "low", "close", "volume"])
+
+    def jointimeframes(self, spec: Dict[str, Dict[str, str]]) -> pd.DataFrame:
+        """Join multiple timeframes into a single DataFrame.
+
+        ``spec`` maps a label to ``{"symbol": str, "timeframe": str}``.
+        Columns are prefixed by the label.
+        """
+        frames = []
+        for label, params in spec.items():
+            df = self.fetchklines(params["symbol"], params["timeframe"])
+            frames.append(df.add_prefix(f"{label}_"))
+        if not frames:
+            return pd.DataFrame()
+        return reduce(lambda l, r: l.join(r, how="outer"), frames)
+
+    def subscribelive(self, symbol: str, timeframe: str, callback: Callable[[pd.DataFrame], Any]) -> None:
+        """Immediately invoke ``callback`` with the latest klines.
+
+        Real-time streaming is out of scope for this lightweight wrapper but the
+        signature mirrors the intended interface.
+        """
+        df = self.fetchklines(symbol, timeframe)
+        callback(df)
+
+
+__all__ = ["DataManager"]

--- a/tradingbot/core/errorhandler.py
+++ b/tradingbot/core/errorhandler.py
@@ -1,0 +1,6 @@
+# file: core/errorhandler.py
+"""Compatibility wrapper for error_handler module."""
+
+from .error_handler import ErrorHandler
+
+__all__ = ["ErrorHandler"]

--- a/tradingbot/core/pairmanager.py
+++ b/tradingbot/core/pairmanager.py
@@ -1,0 +1,6 @@
+# file: core/pairmanager.py
+"""Compatibility wrapper for pair_manager module."""
+
+from .pair_manager import PairManager
+
+__all__ = ["PairManager"]

--- a/tradingbot/core/portfoliomanager.py
+++ b/tradingbot/core/portfoliomanager.py
@@ -1,0 +1,6 @@
+# file: core/portfoliomanager.py
+"""Compatibility wrapper for portfolio_manager module."""
+
+from .portfolio_manager import PortfolioManager
+
+__all__ = ["PortfolioManager"]

--- a/tradingbot/core/riskmanager.py
+++ b/tradingbot/core/riskmanager.py
@@ -1,0 +1,6 @@
+# file: core/riskmanager.py
+"""Compatibility wrapper for risk_manager module."""
+
+from .risk_manager import RiskManager, OrderProposal
+
+__all__ = ["RiskManager", "OrderProposal"]

--- a/tradingbot/core/runtimecontroller.py
+++ b/tradingbot/core/runtimecontroller.py
@@ -1,0 +1,48 @@
+# file: core/runtimecontroller.py
+"""RuntimeController compatibility layer with underscore-free API."""
+
+from __future__ import annotations
+
+from .runtime_controller import RuntimeController as _RuntimeController
+
+
+class RuntimeController(_RuntimeController):
+    """Expose new naming conventions for runtime control operations."""
+
+    def start(self) -> None:
+        """Mark the runtime as started."""
+        self.state.setdefault("global", {})["running"] = True
+        self._save()
+
+    def stop(self) -> None:
+        """Mark the runtime as stopped."""
+        self.state.setdefault("global", {})["running"] = False
+        self._save()
+
+    def enablelive(self, asset: str) -> bool:
+        """Enable live trading for ``asset`` after validation."""
+        super().enable_live(asset)
+        return True
+
+    def disablelive(self, asset: str, closeonly: bool = False) -> None:
+        """Disable live trading for ``asset``."""
+        super().disable_live(asset, close_only=closeonly)
+
+    def setglobalkill(self, active: bool) -> None:
+        """Toggle the global kill switch."""
+        super().set_global_kill(active)
+
+    def recordtraderesult(self, asset: str, islive: bool, pnlafterfees: float) -> None:
+        """Record the result of a trade for loss tracking."""
+        super().record_trade_result(asset, is_live=islive, pnl_after_fees=pnlafterfees)
+
+    def hourlypaperrecap(self) -> None:
+        """Placeholder for hourly paper recap notifications."""
+        self.notifier.send("Hourly paper recap not implemented")
+
+    def getstate(self) -> dict:
+        """Return the current runtime state."""
+        return super().get_state()
+
+
+__all__ = ["RuntimeController"]

--- a/tradingbot/core/tradeexecutor.py
+++ b/tradingbot/core/tradeexecutor.py
@@ -1,0 +1,6 @@
+# file: core/tradeexecutor.py
+"""Compatibility wrapper for trade_executor module."""
+
+from .trade_executor import TradeExecutor
+
+__all__ = ["TradeExecutor"]

--- a/tradingbot/core/validationmanager.py
+++ b/tradingbot/core/validationmanager.py
@@ -1,0 +1,41 @@
+# file: core/validationmanager.py
+"""Compatibility wrapper for validation_manager module with new helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Any
+
+from .validation_manager import ValidationManager as _ValidationManager
+
+
+class ValidationManager(_ValidationManager):
+    """Expose convenience methods using underscore-free names."""
+
+    def savereport(self, report: Dict[str, Any], path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf-8") as fh:
+            json.dump(report, fh, indent=2, default=str)
+
+    def latestreport(self, strategyid: str) -> Dict[str, Any] | None:
+        return super().latest_report(strategyid)
+
+    def eligibleforlive(self, strategyid: str, gates: Dict[str, Any] | None = None) -> bool:
+        passed, _ = super().eligible_for_live(strategyid)
+        if not gates:
+            return passed
+        if not passed:
+            return False
+        report = self.latestreport(strategyid) or {}
+        metrics = report.get("metrics", {})
+        trades = report.get("trades", 0)
+        if trades < gates.get("trades", 0):
+            return False
+        for key, threshold in gates.items():
+            if key in metrics and metrics[key] < threshold:
+                return False
+        return True
+
+
+__all__ = ["ValidationManager"]


### PR DESCRIPTION
## Summary
- Add runtimecontroller wrapper to expose start/stop and underscore-free method names
- Provide datamanager helper with fetchklines, savelocal, loadlocal and live subscription stubs
- Introduce validationmanager and additional wrappers for pair, risk, trade, portfolio and error managers

## Testing
- `pytest -q`
- `pip check`

------
https://chatgpt.com/codex/tasks/task_e_68a7356246608325a6cb2407c1bc2488