### PR TITLE
Add drift monitoring component and tests

### DIFF
--- a/tests/test_driftmonitor.py
+++ b/tests/test_driftmonitor.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from tradingbot.core.driftmonitor import DriftMonitor
+
+
+def test_checkdrift_reports_zscore():
+    baseline = pd.DataFrame({"a": [0, 0, 0, 0], "b": [1, 1, 1, 1]})
+    features = pd.DataFrame({"a": [0, 0, 1, 1], "b": [1, 2, 1, 2]})
+    dm = DriftMonitor(threshold=2)
+    report = dm.checkdrift(features, baseline)
+    assert "a" in report and "b" in report
+    assert report["a"]["zscore"] != 0
+    assert report["max_zscore"] >= max(abs(report["a"]["zscore"]), abs(report["b"]["zscore"]))
+
+
+def test_alertifdrift_triggers_notifier():
+    baseline = pd.DataFrame({"x": [0, 0, 0, 0]})
+    features = pd.DataFrame({"x": [10, 10, 10, 10]})
+    dm = DriftMonitor(threshold=1)
+    report = dm.checkdrift(features, baseline)
+    dm.alertifdrift(report)
+    assert dm.notifier.messages  # should contain alert
+
+
+def test_alertifdrift_no_alert_below_threshold():
+    baseline = pd.DataFrame({"x": [0, 0, 0, 0]})
+    features = pd.DataFrame({"x": [0.1, -0.1, 0.2, -0.2]})
+    dm = DriftMonitor(threshold=5)
+    report = dm.checkdrift(features, baseline)
+    dm.alertifdrift(report)
+    assert not dm.notifier.messages

--- a/tradingbot/core/driftmonitor.py
+++ b/tradingbot/core/driftmonitor.py
@@ -1,0 +1,54 @@
+# file: core/driftmonitor.py
+"""Drift monitoring utilities for feature drift detection.
+
+This lightweight implementation compares the mean of each feature against a
+baseline and reports a z-score.  It also integrates with the :class:`Notifier`
+so that alerts can be emitted when drift exceeds a configurable threshold.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pandas as pd
+
+from .notifier import Notifier
+
+
+class DriftMonitor:
+    """Detect simple feature drift based on mean deviation."""
+
+    def __init__(self, notifier: Notifier | None = None, threshold: float = 3.0) -> None:
+        self.notifier = notifier or Notifier()
+        self.threshold = threshold
+
+    def checkdrift(self, features: pd.DataFrame, baseline: pd.DataFrame) -> Dict[str, Any]:
+        """Return drift statistics comparing ``features`` to ``baseline``.
+
+        The result maps each common column to a dictionary with the mean
+        difference and z-score relative to the baseline's standard deviation.
+        ``max_zscore`` contains the maximum absolute z-score across all
+        features for quick threshold checks.
+        """
+        report: Dict[str, Any] = {}
+        columns = sorted(set(features.columns) & set(baseline.columns))
+        for column in columns:
+            f = features[column].dropna()
+            b = baseline[column].dropna()
+            if b.empty or f.empty:
+                continue
+            mean_diff = f.mean() - b.mean()
+            std = b.std() or 1.0
+            z = mean_diff / std
+            report[column] = {"mean_diff": float(mean_diff), "zscore": float(z)}
+        report["max_zscore"] = max((abs(v["zscore"]) for v in report.values()), default=0.0)
+        return report
+
+    def alertifdrift(self, report: Dict[str, Any]) -> None:
+        """Send an alert if the drift report exceeds the configured threshold."""
+        max_z = report.get("max_zscore", 0.0)
+        if max_z > self.threshold:
+            self.notifier.send(f"drift detected: z={max_z:.2f}")
+
+
+__all__ = ["DriftMonitor"]


### PR DESCRIPTION
## Summary
- implement drift monitor with simple z-score based detection and notifier alerts
- add unit tests covering drift reporting and alert logic

## Testing
- `pip check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a73b9cb42c8325bd26049bfa9a6ec1