### PR TITLE
Add feature store utilities

### DIFF
--- a/tradingbot/core/feature_store.py
+++ b/tradingbot/core/feature_store.py
@@ -1,0 +1,41 @@
+# file: core/feature_store.py
+"""Feature store utilities for persisting and validating feature DataFrames."""
+
+from pathlib import Path
+
+import pandas as pd
+from jsonschema import validate as jsonschema_validate
+
+
+def _feature_path(symbol: str, version: str, base_path: Path | None = None) -> Path:
+    """Construct the filesystem path for a feature set."""
+    base = base_path or Path(__file__).resolve().parent.parent / "state"
+    return base / "features" / symbol / f"{version}.parquet"
+
+
+def save_features(
+    symbol: str,
+    features: pd.DataFrame,
+    version: str,
+    base_path: Path | None = None,
+) -> Path:
+    """Persist features to a versioned Parquet file and return its path."""
+    path = _feature_path(symbol, version, base_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    features.to_parquet(path)
+    return path
+
+
+def load_features(
+    symbol: str,
+    version: str,
+    base_path: Path | None = None,
+) -> pd.DataFrame:
+    """Load a feature DataFrame from a versioned Parquet file."""
+    path = _feature_path(symbol, version, base_path)
+    return pd.read_parquet(path)
+
+
+def validate_features(features: pd.DataFrame, schema: dict) -> None:
+    """Validate a feature DataFrame's metadata using a JSON schema."""
+    jsonschema_validate(instance=features.attrs, schema=schema)


### PR DESCRIPTION
## Summary
- add feature store helpers for saving and loading versioned feature sets
- include JSON-schema validation for DataFrame metadata

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a87a313b2883259a668d5e9420c2cd