### PR TITLE
feat: enhance trade executor with slippage and mode routing

### DIFF
--- a/tradingbot/core/trade_executor.py
+++ b/tradingbot/core/trade_executor.py
@@ -1,3 +1,8 @@
+"""
+Order execution routing with slippage, fee reconciliation, and mode switching.
+"""
+
+# file: core/trade_executor.py
 import logging
 from typing import Dict, Any, Optional
 
@@ -22,6 +27,60 @@ class TradeExecutor:
         self.ibkr_adapter = ibkr_adapter
         self.bot_settings = config_manager.get_config().get("bot_settings", {})
         self.account_scope = self.bot_settings.get("account_scope", {})
+        safety = config_manager.get_config().get("safety", {})
+        self.mode = safety.get("START_MODE", "paper")
+
+    def _get_asset_key(self, broker: Any) -> str:
+        """Infer asset config key based on the broker type."""
+        if isinstance(broker, ExchangeBybit):
+            return "crypto_spot"
+        return "forex"
+
+    def _apply_slippage(self, order: Order, slippage_bps: float) -> Order:
+        """Apply slippage (in basis points) to the order prices."""
+        if slippage_bps <= 0:
+            return order
+
+        adjusted = order.copy(deep=True)
+        multiplier = 1 + (slippage_bps / 10000) if order.side == "buy" else 1 - (slippage_bps / 10000)
+        if adjusted.limit_price:
+            adjusted.limit_price *= multiplier
+        if adjusted.stop_loss:
+            adjusted.stop_loss *= multiplier
+        if adjusted.take_profit:
+            adjusted.take_profit *= multiplier
+        return adjusted
+
+    async def _apply_fees_and_reconcile(
+        self,
+        broker: Any,
+        order: Order,
+        result: Dict[str, Any],
+        asset_key: str,
+    ) -> Dict[str, Any]:
+        """Annotate result with fee info and updated positions."""
+        asset_cfg = config_manager.get_asset_config(asset_key)
+        fees = asset_cfg.get("fees", {})
+        fee_rate = fees.get("maker" if order.order_type == "limit" else "taker", 0)
+        price = result.get("price") or order.limit_price or 0
+        result["fee"] = price * order.quantity * fee_rate
+
+        if hasattr(broker, "get_positions"):
+            try:
+                if isinstance(broker, ExchangeBybit):
+                    result["positions"] = await broker.get_positions("linear")
+                else:
+                    result["positions"] = await broker.get_positions()
+            except Exception as e:
+                logger.warning(f"Failed to reconcile positions: {e}")
+
+        return result
+
+    async def _execute_oco_order(self, broker: Any, order: Order) -> Dict[str, Any]:
+        """Execute an order with stop-loss and take-profit legs."""
+        if hasattr(broker, "place_oco_order"):
+            return await broker.place_oco_order(order)
+        return await broker.place_order(order)
 
     def _get_broker_for_symbol(self, symbol: str) -> Optional[Any]:
         """Determines which broker to use for a given symbol."""
@@ -51,10 +110,30 @@ class TradeExecutor:
             return {"status": "REJECTED", "reason": msg}
 
         try:
-            logger.info(f"Routing order {order.order_id} for {order.symbol} to {broker.__class__.__name__}")
-            result = await broker.place_order(order)
+            asset_key = self._get_asset_key(broker)
+            asset_cfg = config_manager.get_asset_config(asset_key)
+            slippage_bps = asset_cfg.get("slippage_bps", 0)
+            adjusted_order = self._apply_slippage(order, slippage_bps)
+
+            logger.info(
+                f"Routing order {adjusted_order.order_id} for {adjusted_order.symbol} to {broker.__class__.__name__} in {self.mode} mode"
+            )
+
+            if self.mode == "paper":
+                result = {"status": "FILLED", "simulated": True, "mode": "paper"}
+            else:
+                if adjusted_order.stop_loss and adjusted_order.take_profit:
+                    result = await self._execute_oco_order(broker, adjusted_order)
+                else:
+                    result = await broker.place_order(adjusted_order)
+
+            result = await self._apply_fees_and_reconcile(
+                broker, adjusted_order, result, asset_key
+            )
             return result
         except Exception as e:
-            msg = f"An error occurred while executing order {order.order_id} on {broker.__class__.__name__}: {e}"
+            msg = (
+                f"An error occurred while executing order {order.order_id} on {broker.__class__.__name__}: {e}"
+            )
             logger.exception(msg)
             return {"status": "ERROR", "reason": msg}


### PR DESCRIPTION
## Summary
- add header and logging for `trade_executor`
- support configurable slippage and OCO orders
- reconcile fees/positions and route paper vs live modes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a87a4a49748325ba82097b971e7f53